### PR TITLE
fix: ensures old howler instances are unloaded on change

### DIFF
--- a/src/AudioPlayerProvider.tsx
+++ b/src/AudioPlayerProvider.tsx
@@ -60,6 +60,9 @@ export function AudioPlayerProvider({
                     prevPlayer.current.once("load", () => {
                         prevPlayer.current?.unload()
                     })
+                } else {
+                    prevPlayer.current = playerRef.current
+                    prevPlayer.current?.unload()
                 }
 
                 wasPlaying = playerRef.current.playing()


### PR DESCRIPTION
Here is a quick PR that is in reference to #85 

The following commit ensures that the existing howler instance is unloaded when a new source is loaded.

Previously, there was only a check in place to unload a howler instance if the instance had not loaded yet. This was handled by creating an event listener and waiting for the howler to emit its `loaded` event, and then subsequently unload it. Therefore, the new `else` statement ensures that even "loaded" (as determined by the reducer) howler instances are removed when a new source is loaded.

For consistency, I also set the current `playerRef` to `prevPlayer` to not mess with any methods called after this `else` statement. This is how it's handled in the `if` statement so I figured this would be the best approach. 

Hope this helps a bit! All 2 lines of it 😄 

P.S. Wonder how many more times I can say the word loaded