### PR TITLE
feat: expose underlying Howl instance and events to the client to allow for greater expandability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ function MyComponent() {
   load('/mySound.wav', {
     autoplay: true
   });
+
+  // the howler instance is exposed from load() as well
+  const howler = load('/mySound.wav', {})
 }
 ```
 
@@ -117,9 +120,13 @@ Sets or unsets whether the sound should loop once it ends
 #### getPosition `() => number`
 Returns the current position of the loaded sound as a floating point number
 
-#### load `(src: string, options?: AudioLoadOptions) => void`
+#### getHowl `() => Howl`
+Returns the current Howler instance being used
+
+#### load `(src: string, options?: AudioLoadOptions) => Howl`
 Downloads and loads a new sound. The first argument, src is a URI of the sound to be played. The second argument is a set of options applied to the sound once it loads.
 These options can be used to initialize certain pieces of state on the `AudioPlayer` interface or be used to set up lifecycle callbacks if needed.
+This method returns the Howler instance being used.
 
 `AudioLoadOptions`
 - loop?: boolean (sets the initial loop state once the sound loads)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./useAudioPlayer"
 export * from "./useGlobalAudioPlayer"
+export * from "./useHowlEventSync"
 export * from "./types"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { AudioPlayerState } from "./audioPlayerState"
+import { Howl } from "howler"
 
 export interface AudioPlayer extends AudioPlayerState {
     play: () => void
@@ -12,6 +13,7 @@ export interface AudioPlayer extends AudioPlayerState {
     mute: (muteOnOff: boolean) => void
     loop: (loopOnOff: boolean) => void
     getPosition: () => number
+    getHowl: () => Howl | undefined
     load: (...args: LoadArguments) => void
 }
 

--- a/src/useAudioPlayer.ts
+++ b/src/useAudioPlayer.ts
@@ -42,6 +42,8 @@ export const useAudioPlayer = (): AudioPlayer => {
         })
 
         dispatch({ type: "START_LOAD", howl })
+
+        return howl
     }, [])
 
     const seek = useCallback((seconds: number) => {
@@ -149,11 +151,16 @@ export const useAudioPlayer = (): AudioPlayer => {
         dispatch({ type: "ON_LOOP", howl, toggleValue: loopOnOff })
     }, [])
 
+    const getHowl = useCallback(() => {
+        return getHowlManager().getHowl()
+    }, [])
+
     return {
         ...state,
         load,
         seek,
         getPosition,
+        getHowl,
         play,
         pause,
         togglePlayPause,

--- a/src/useGlobalAudioPlayer.ts
+++ b/src/useGlobalAudioPlayer.ts
@@ -41,10 +41,12 @@ export function useGlobalAudioPlayer(): AudioPlayer {
     }, [])
 
     const load = useCallback((...[src, options = {}]: LoadArguments) => {
-        howlManager.current.createHowl({
+        const howl = howlManager.current.createHowl({
             src,
             ...options
         })
+
+        return howl
     }, [])
 
     const seek = useCallback((seconds: number) => {
@@ -154,11 +156,16 @@ export function useGlobalAudioPlayer(): AudioPlayer {
         })
     }, [])
 
+    const getHowl = useCallback(() => {
+        return howlManager.current.getHowl()
+    }, [])
+
     return {
         ...state,
         load,
         seek,
         getPosition,
+        getHowl,
         play,
         pause,
         togglePlayPause,


### PR DESCRIPTION
Prior to v2 the Howler instance was exposed. I needed access to the Howler api to get the audio context for recording.
This PR attempts to add back that ability by adding a `getHowl()` method to the hooks.
I also wanted to expose `useHowlEventSync` so that the events could be listened to outside the hooks.

- Add type `getHowl` as Howl to `AudioPlayer`. 
- Add the method `getHowl` to `useAudioPlayer`. 
- Return the `howl` instance in `useAudioPlayer().load()`. 
- Add the method `getHowl` to `useGlobalAudioPlayer`. 
- Return the `howl` instance in `useGlobalAudioPlayer().load()`. 
- Export `useHowlEventSync` from the package to allow external usage of the events.

Resolves the previously closed issues: #50 (resolved by this [PR](https://github.com/E-Kuerschner/useAudioPlayer/pull/51#issue-709755867) ).