### PR TITLE
Remove useAudioPlayer useEffect in favor of explicit clean function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ If the answer is yes to both of these questions, then useGlobalAudioPlayer is th
 This means that you can load and play multiple sounds from the same component. 
 For example, you could add separate, unique sound effects for the success and error responses of a fetch request.
 
-**Note:** Unlike useGlobalAudioPlayer, when the component which initialized the hook unmounts the sound will stop.
+**Note:** Unlike useGlobalAudioPlayer, useAudioPlayer returns an additional method for cleaning up audio if you wish to stop playing and destroy the sound after some interaction (i.e. component unmount, user navigates to a different route, etc.). 
+Without cleaning up, sounds may live on even after the components that created them unmount possibly leading to memory leaks.
 
 useGlobalAudioPlayer and useAudioPlayer can be used simultaneously without one affecting the other.
 

--- a/examples/src/MultipleSounds/index.tsx
+++ b/examples/src/MultipleSounds/index.tsx
@@ -27,7 +27,15 @@ export const MultipleSounds = () => {
 
     return (
         <div className="page multipleSounds">
-            <Link to="..">go back</Link>
+            <Link
+                to=".."
+                onClick={() => {
+                    song1.cleanup()
+                    song2.cleanup()
+                }}
+            >
+                go back
+            </Link>
             <div className="multipleSounds__tracks">
                 <div className="multipleSounds__track">
                     <p>{song1.src}</p>

--- a/examples/src/Streaming/index.tsx
+++ b/examples/src/Streaming/index.tsx
@@ -1,22 +1,6 @@
 import React, { useEffect } from "react"
 import { useAudioPlayer } from "react-use-audio-player"
 import "./styles.scss"
-import { Howl } from "howler"
-
-// const howl = new Howl({
-//     src: "http://mp3-128.streamthejazzgroove.com",
-//     html5: true,
-//     autoplay: false,
-//     format: "mp3"
-// })
-//
-// setInterval(function() {
-//     const elem = document.getElementById("stateupdate")
-//     const state = howl.state()
-//     if (elem) {
-//         elem.innerHTML = `<div>${state.toUpperCase()}</div>`
-//     }
-// }, 100)
 
 export function Streaming() {
     const player = useAudioPlayer()

--- a/src/audioPlayerState.ts
+++ b/src/audioPlayerState.ts
@@ -20,6 +20,8 @@ export type StartLoadAction = {
     howl: Howl
 }
 
+// TODO: the main state reducer should be decoupled from Howler
+// to accomplish this, each action should describe the type of change using an abstraction rather than passing in the howl
 export type AudioEventAction = {
     type: Exclude<ActionTypes, ActionTypes.START_LOAD | ActionTypes.ON_ERROR>
     howl: Howl
@@ -89,40 +91,39 @@ export function initStateFromHowl(howl?: Howl): AudioPlayerState {
 
 export function reducer(state: AudioPlayerState, action: Action) {
     switch (action.type) {
-        case "START_LOAD":
+        case ActionTypes.START_LOAD:
             return {
                 // when called without a Howl object it will return an empty/init state object
                 ...initStateFromHowl(),
-                isLoading: true,
-                linkMediaSession: action.linkMediaSession ?? false
+                isLoading: true
             }
-        case "ON_LOAD":
+        case ActionTypes.ON_LOAD:
             // in React 18 there is a weird race condition where ON_LOAD receives a Howl object that has been unloaded
             // if we detect this case just return the existing state to wait for another action
             if (action.howl.state() === "unloaded") {
                 return state
             }
             return initStateFromHowl(action.howl)
-        case "ON_ERROR":
+        case ActionTypes.ON_ERROR:
             return {
                 // this essentially resets state when called with undefined
                 ...initStateFromHowl(),
                 error: action.message
             }
-        case "ON_PLAY":
+        case ActionTypes.ON_PLAY:
             return {
                 ...state,
                 playing: true,
                 paused: false,
                 stopped: false
             }
-        case "ON_PAUSE":
+        case ActionTypes.ON_PAUSE:
             return {
                 ...state,
                 playing: false,
                 paused: true
             }
-        case "ON_STOP": {
+        case ActionTypes.ON_STOP: {
             return {
                 ...state,
                 playing: false,
@@ -130,32 +131,32 @@ export function reducer(state: AudioPlayerState, action: Action) {
                 stopped: true
             }
         }
-        case "ON_END": {
+        case ActionTypes.ON_END: {
             return {
                 ...state,
                 playing: state.looping,
                 stopped: !state.looping
             }
         }
-        case "ON_MUTE": {
+        case ActionTypes.ON_MUTE: {
             return {
                 ...state,
                 muted: action.howl.mute() ?? false
             }
         }
-        case "ON_RATE": {
+        case ActionTypes.ON_RATE: {
             return {
                 ...state,
                 rate: action.howl?.rate() ?? 1.0
             }
         }
-        case "ON_VOLUME": {
+        case ActionTypes.ON_VOLUME: {
             return {
                 ...state,
                 volume: action.howl?.volume() ?? 1.0
             }
         }
-        case "ON_LOOP": {
+        case ActionTypes.ON_LOOP: {
             const { toggleValue = false, howl } = action
             howl.loop(toggleValue)
             return {

--- a/src/useGlobalAudioPlayer.ts
+++ b/src/useGlobalAudioPlayer.ts
@@ -42,6 +42,7 @@ export function useGlobalAudioPlayer(): AudioPlayer {
     }, [])
 
     const load = useCallback((...[src, options = {}]: LoadArguments) => {
+        // the HowlInstanceManager will intercept this newly created howl and broadcast it to registered hooks
         howlManager.current.createHowl({
             src,
             ...options

--- a/src/useHowlEventSync.ts
+++ b/src/useHowlEventSync.ts
@@ -97,7 +97,7 @@ export function useHowlEventSync(
     // using ref bc we don't want identity of dispatch function to change
     // see talk: https://youtu.be/nUzLlHFVXx0?t=1558
     const wrappedDispatch = useRef((action: Action) => {
-        if (action.type === "START_LOAD") {
+        if (action.type === ActionTypes.START_LOAD) {
             const { howl } = action
             // set up event listening
             howl.once("load", onLoad)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,9 +3972,9 @@ hosted-git-info@^2.1.4:
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 howler@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.3.tgz#a2eff9b08b586798e7a2ee17a602a90df28715da"
-  integrity sha512-QM0FFkw0LRX1PR8pNzJVAY25JhIWvbKMBFM4gqk+QdV+kPXOhleWGCB6AiAF/goGjIHK2e/nIElplvjQwhr0jg==
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.4.tgz#bd3df4a4f68a0118a51e4bd84a2bfc2e93e6e5a1"
+  integrity sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR remove the useEffect from useAudioPlayer which was automatically destroying Howl objects as the component unmounted. This was causing bugs in certain scenarios, mainly when trying to sync the Howl up to the MediaSession in the browser. While this feature has been descoped (see Issues), using an effect for this can still lead to unexpected behaviors and a more explicit cleanup function is preferred.