### PR TITLE
Return `muted` as a boolean instead of a function

### DIFF
--- a/packages/react-use-audio-player/src/audioPlayerState.ts
+++ b/packages/react-use-audio-player/src/audioPlayerState.ts
@@ -81,7 +81,8 @@ export function initStateFromHowl(howl?: Howl): AudioPlayerState {
         duration: howl.duration(),
         rate: howl.rate(),
         volume: howl.volume(),
-        muted: howl.mute(),
+        // @ts-ignore _muted exists
+        muted: howl._muted,
         playing,
         paused: !playing,
         stopped: !playing && position === 0,


### PR DESCRIPTION
Currently this returns the `howl.mute` which returns the entire Howler object, but the type says this should be a boolean.

Looking at [howler.js](https://github.com/goldfire/howler.js/blob/a2a47933f1ffcee659e4939a65e075fa7f25706c/src/howler.core.js#L1153), it looks like the mute boolean is never publicly exposed from Howler, unfortunately. From testing, just checking the volume at 0 doesn't work.

It's not great to expose private properties like this, but I expect Howler to be stable enough and this is better than existing functionality.