### PR TITLE
4.0.2

### DIFF
--- a/demos/showcase/src/App.tsx
+++ b/demos/showcase/src/App.tsx
@@ -3,6 +3,7 @@ import { FullFeaturesDemo } from "./FullFeaturesDemo.tsx"
 import { CrossFaderDemo } from "./CrossFaderDemo.tsx"
 import { StreamingDemo } from "./StreamingDemo.tsx"
 import { DeclarativeDemo } from "./DeclarativeDemo.tsx"
+import { DebuggingRoute } from "./DebuggingRoute.tsx"
 import DemoPicker from "./DemoPicker.tsx"
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
                     <Route path="streaming" element={<StreamingDemo />} />
                     <Route path="fullFeatures" element={<FullFeaturesDemo />} />
                     <Route path="declarative" element={<DeclarativeDemo />} />
+                    <Route path="debugging" element={<DebuggingRoute />} />
                 </Routes>
             </BrowserRouter>
         </div>

--- a/demos/showcase/src/DebuggingRoute.tsx
+++ b/demos/showcase/src/DebuggingRoute.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react"
+import { Howl } from "howler"
+
+export const DebuggingRoute = () => {
+    const soundRef = useRef<Howl | null>(null)
+    useEffect(() => {
+        if (soundRef.current) return
+
+        soundRef.current = new Howl({
+            src: ["/ch_tunes - baby_seal.wav"],
+            html5: true // Enables html5 audio for streaming large files
+        })
+
+        soundRef.current.on("seek", function () {
+            console.log(soundRef.current?.state())
+        })
+        soundRef.current.on("load", function () {
+            console.log(soundRef.current?.state())
+        })
+    }, [])
+
+    return (
+        <div>
+            <button onClick={() => soundRef.current?.play()}>Play</button>
+            <button onClick={() => soundRef.current?.seek(10)}>seek</button>
+        </div>
+    )
+}

--- a/demos/showcase/src/FullFeaturesDemo.tsx
+++ b/demos/showcase/src/FullFeaturesDemo.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react"
+import { useLocation } from "react-router-dom"
 import { useAudioPlayer } from "react-use-audio-player"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
@@ -64,9 +65,12 @@ export function FullFeaturesDemo() {
         setPlayerFadeOut(false)
     }, [setVolume, initialVolume, setPlayerFadeOut])
 
+    const location = useLocation()
+    const params = new URLSearchParams(location.search)
     const handleTrackSelect = (src?: string) => {
         if (src) {
             load(src, {
+                html5: params.get("html5") === "true",
                 autoplay,
                 initialVolume: initialVolume,
                 initialRate: initialPlaybackRate,

--- a/packages/react-use-audio-player/CHANGELOG.md
+++ b/packages/react-use-audio-player/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes made to this project from v3.0.0 and up will be documented in this file. This project uses semver standards.
 
+## 4.0.2 (2025-03-16)
+
+### Fixes 🐛
+
+- Fixes issue [#166](https://github.com/E-Kuerschner/useAudioPlayer/issues/166) in which the hook can get stuck in a loading state after seeking on an audio resource loaded via HTML5 audio elements 
+- Fixes issue [#105](https://github.com/E-Kuerschner/useAudioPlayer/issues/105) in which seeking on streaming audio would cause an error
+
+### Other
+
+- Add page for debugging to the showcase demo app
+
 ## 4.0.1 (2025-03-02)
 
 ### Fixes 🐛

--- a/packages/react-use-audio-player/package.json
+++ b/packages/react-use-audio-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-audio-player",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "type": "module",
   "packageManager": "yarn@4.6.0",
   "sideEffects": false,

--- a/packages/react-use-audio-player/src/HowlStore.ts
+++ b/packages/react-use-audio-player/src/HowlStore.ts
@@ -289,8 +289,8 @@ export class HowlStore implements AudioControls {
     }
 
     public seek(seconds: number) {
-        if (this.howl) {
-            // TODO if unloaded set initial start time?
+        // if audio resource is being streamed then it's duration will be Infinity
+        if (this.howl && this.snapshot.duration !== Infinity) {
             this.howl.seek(seconds)
         }
     }

--- a/packages/react-use-audio-player/src/types.ts
+++ b/packages/react-use-audio-player/src/types.ts
@@ -1,3 +1,13 @@
+// module augmentation to get access to the fields/types I need from Howl interface
+declare module "howler" {
+    interface Howl {
+        _html5: boolean
+        _sounds: Array<{
+            _node?: HTMLAudioElement
+        }>
+    }
+}
+
 /**
  * Describes the full API of state-mutating actions one can perform on the audio
  */


### PR DESCRIPTION
### Fixes 🐛

- Fixes issue [#166](https://github.com/E-Kuerschner/useAudioPlayer/issues/166) in which the hook can get stuck in a loading state after seeking on an audio resource loaded via HTML5 audio elements 
- Fixes issue [#105](https://github.com/E-Kuerschner/useAudioPlayer/issues/105) in which seeking on streaming audio would cause an error